### PR TITLE
Set Boost_NO_BOOST_CMAKE to ON, to disable the search for boost-cmake.

### DIFF
--- a/stitcher/CMakeLists.txt
+++ b/stitcher/CMakeLists.txt
@@ -7,6 +7,9 @@ find_package(OpenCV 4.2 REQUIRED)
 # Boost is a development dependency and this binary has very 
 # little to ask from Boost, so linking statically
 set(Boost_USE_STATIC_LIBS ON)
+# Force Boost_LIBRARIES, see: 
+# https://stackoverflow.com/questions/56036266/boost-libraries-not-defined
+set(Boost_NO_BOOST_CMAKE ON)
 find_package(
     Boost REQUIRED
     program_options
@@ -16,6 +19,7 @@ include_directories(
     include
     3rdParty
     ${OpenCV_INCLUDE_DIRS}
+    ${Boost_INCLUDE_DIRS}
 )
 
 add_library(


### PR DESCRIPTION
see: https://stackoverflow.com/questions/56036266/boost-libraries-not-defined