### PR TITLE
android oom crash ->? inputBudgetMultiplier to 5

### DIFF
--- a/stitcher/CMakeLists.txt
+++ b/stitcher/CMakeLists.txt
@@ -4,12 +4,9 @@ project("airmap-panorama-stitcher")
 
 find_package(OpenCV 4.2 REQUIRED)
 
-# Boost is a development dependency and this binary has very 
+# Boost is a development dependency and this binary has very
 # little to ask from Boost, so linking statically
 set(Boost_USE_STATIC_LIBS ON)
-# Force Boost_LIBRARIES, see: 
-# https://stackoverflow.com/questions/56036266/boost-libraries-not-defined
-set(Boost_NO_BOOST_CMAKE ON)
 find_package(
     Boost REQUIRED
     program_options
@@ -19,7 +16,6 @@ include_directories(
     include
     3rdParty
     ${OpenCV_INCLUDE_DIRS}
-    ${Boost_INCLUDE_DIRS}
 )
 
 add_library(
@@ -45,7 +41,7 @@ target_link_libraries(
 target_link_libraries(
     airmap_stitcher
     airmap_stitching
-    ${Boost_LIBRARIES}
+    Boost::program_options
 )
 
 #


### PR DESCRIPTION
The scaling factor is calculated as the lower of:
- that implied by the max image size 
- that implied by the RAM budget divided by the 'inputBudgetMultiplier'

it is then moved by +/-1% to randomise the problem and increase the chances of the retry budget.

### Analysis
All Anafi datasets are consistently scaled at 0.8, let's see where is this number from:
```
Stitching "/storage/emulated/0/CustomQGC/Photo/6-panaroma-sean/.airboss/panoramas/WlJ+5C303k_abA4uiSX9yA==/panorama.jpg, no images: 24,
D AirBoss Mission Planner Daily: Panoramas360Log: Scaled 1080 MB of input to 870.428 MB (by  0.805952 ), the lesser of:
D AirBoss Mission Planner Daily: Panoramas360Log: -  0.953909 to fit the given RAM budget of 4636 MB and
D AirBoss Mission Planner Daily: Panoramas360Log: -  0.8 max input image size of 4121 x 3090
...
D AirBoss Mission Planner Daily: Panoramas360Log: Stitching "/storage/emulated/0/CustomQGC/Photo/anafi-360-300ft/.airboss/panoramas/GHx5PfuXt4PZBIsimEBkzQ==/panorama.jpg, no images: 25, images taken (exif): [Tue Nov 3 20:33:19 2020..Tue Nov 3 20:34:14 2020]"
D AirBoss Mission Planner Daily: Panoramas360Log: Scaled 1125 MB of input to 900.056 MB (by  0.80005 ), the lesser of:
D AirBoss Mission Planner Daily: Panoramas360Log: -  0.915753 to fit the given RAM budget of 4636 MB and
D AirBoss Mission Planner Daily: Panoramas360Log: -  0.8 max input image size of 4121 x 3090
...
D AirBoss Mission Planner Daily: Panoramas360Log: Stitching "/storage/emulated/0/CustomQGC/Photo/2-panorama-dezio/sub2/.airboss/panoramas/Clh2AMO76bZlv+srShRqVg==/panorama.jpg, no images: 27, images taken (exif): [Wed Nov 11 16:11:26 2020..Wed Nov 11 16:12:26 2020]"
D AirBoss Mission Planner Daily: Panoramas360Log: Scaled 1215 MB of input to 963.341 MB (by  0.792873 ), min between:
D AirBoss Mission Planner Daily: Panoramas360Log: -  0.84792 to fit the given RAM budget of 4636 MB and
D AirBoss Mission Planner Daily: Panoramas360Log: -  0.8  max input image size of 4121 x 3090
"com.airmap.airboss" died.
```
Note that the max input size always overpowers the RAM budget limitation (for the 4GB device) and also note that the last (failing) dataset has 27 images, while the other (succeeding) sets have 25/24 images. 

The largest succeeding dataset is 900MB, the smallest failing 963MB it seems the truth is somewhere in the middle and there is a problem with the 'inputBudgetMultiplier' underestimating the amount of RAM needed for the given input. 

`inputBudgetMultiplier` :5 - succeeding
```
D AirBoss Mission Planner Daily: Panoramas360Log: Stitching "/storage/emulated/0/CustomQGC/Photo/2-panorama-dezio/sub2/.airboss/panoramas/Clh2AMO76bZlv+srShRqVg==/panorama.jpg, no images: 27, images taken (exif): [Wed Nov 11 16:11:26 2020..Wed Nov 11 16:12:26 2020]"
D AirBoss Mission Planner Daily: Panoramas360Log: Scaled 1215 MB of input to 919.566 MB (by  0.756845 ), the lesser of:
D AirBoss Mission Planner Daily: Panoramas360Log: -  0.763128 to fit the given RAM budget of 4636 MB and
D AirBoss Mission Planner Daily: Panoramas360Log: -  0.8 max input image size of 4121 x 3090
```
`inputBudgetMultiplier` :4.9 - succeeding
```
D AirBoss Mission Planner Daily: Panoramas360Log: Stitching "/storage/emulated/0/CustomQGC/Photo/2-panorama-dezio/sub2/.airboss/panoramas/Clh2AMO76bZlv+srShRqVg==/panorama.jpg, no images: 27, images taken (exif): [Wed Nov 11 16:11:26 2020..Wed Nov 11 16:12:26 2020]"
D AirBoss Mission Planner Daily: Panoramas360Log: Scaled 1215 MB of input to 941.015 MB (by  0.774498 ), the lesser of:
D AirBoss Mission Planner Daily: Panoramas360Log: -  0.778702 to fit the given RAM budget of 4636 MB and
D AirBoss Mission Planner Daily: Panoramas360Log: -  0.8 max input image size of 4121 x 3090
```
`inputBudgetMultiplier` :4.8 - failing - this is where they meet.
```
D AirBoss Mission Planner Daily: Panoramas360Log: Stitching "/storage/emulated/0/CustomQGC/Photo/2-panorama-dezio/sub2/.airboss/panoramas/Clh2AMO76bZlv+srShRqVg==/panorama.jpg, no images: 27, images taken (exif): [Wed Nov 11 16:11:26 2020..Wed Nov 11 16:12:26 2020]"
D AirBoss Mission Planner Daily: Panoramas360Log: Scaled 1215 MB of input to 975.015 MB (by  0.802482 ), the lesser of:
D AirBoss Mission Planner Daily: Panoramas360Log: -  0.794925 to fit the given RAM budget of 4636 MB and
D AirBoss Mission Planner Daily: Panoramas360Log: -  0.8 max input image size of 4121 x 3090
```
One last thing; need to verify that the new multiplier only affects (scales more aggressively) the dataset in question (and because it has more images)
```
D AirBoss Mission Planner Daily: Panoramas360Log: Stitching "/storage/emulated/0/CustomQGC/Photo/2-panorama-dezio/sub2/.airboss/panoramas/Clh2AMO76bZlv+srShRqVg==/panorama.jpg, no images: 27, images taken (exif): [Wed Nov 11 16:11:26 2020..Wed Nov 11 16:12:26 2020]"
D AirBoss Mission Planner Daily: Panoramas360Log: Scaled 1215 MB of input to 931.505 MB (by  0.76667 ), the lesser of:
D AirBoss Mission Planner Daily: Panoramas360Log: -  0.763128 to fit the given RAM budget of 4636 MB and
D AirBoss Mission Planner Daily: Panoramas360Log: -  0.8 max input image size of 4121 x 3090
...

D AirBoss Mission Planner Daily: Panoramas360Log: Stitching "/storage/emulated/0/CustomQGC/Photo/6-panaroma-sean/.airboss/panoramas/WlJ+5C303k_abA4uiSX9yA==/panorama.jpg, no images: 24, images taken (exif): [Thu Jan 1 01:00:00 1970..Thu Jan 1 01:00:00 1970]"
D AirBoss Mission Planner Daily: Panoramas360Log: Scaled 1080 MB of input to 864.825 MB (by  0.800764 ), the lesser of:
D AirBoss Mission Planner Daily: Panoramas360Log: -  0.858519 to fit the given RAM budget of 4636 MB and
D AirBoss Mission Planner Daily: Panoramas360Log: -  0.8 max input image size of 4121 x 3090
...
D AirBoss Mission Planner Daily: Panoramas360Log: Stitching "/storage/emulated/0/CustomQGC/Photo/anafi-360-300ft/.airboss/panoramas/GHx5PfuXt4PZBIsimEBkzQ==/panorama.jpg, no images: 25, images taken (exif): [Tue Nov 3 20:33:19 2020..Tue Nov 3 20:34:14 2020]"
D AirBoss Mission Planner Daily: Panoramas360Log: Scaled 1125 MB of input to 900.685 MB (by  0.800609 ), the lesser of:
D AirBoss Mission Planner Daily: Panoramas360Log: -  0.824178 to fit the given RAM budget of 4636 MB and
D AirBoss Mission Planner Daily: Panoramas360Log: -  0.8 max input image size of 4121 x 3090

```
### How to test
Android device with 4GB or less:
- download [the dataset](https://drive.google.com/file/d/1gh73L3JR96Q-9RiIDkTXFqcw1iakN5af/view) and put to `CustomQGC/Photo` on said device
- confirm if you can reproduce the crash at least once (run it up to 3 times) - i am worried that I don't have a device with less than 4GB - the relationship between the RAM budget and problem size may not be linear.
- confirm the crash goes away with this PR. 

if you can't build an apk - [here's](https://drive.google.com/file/d/1ys004kEfq6KIl4KtmhKi6KpAX7KF1OWb/view?usp=sharing) one i built. 