### PR TITLE
[BOSS-758] add coverage script

### DIFF
--- a/scripts/coverage.bash
+++ b/scripts/coverage.bash
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -xeuo pipefail
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+cd "${HERE}/.."
+
+mkdir -p build
+cd build
+BUILD_DIR="$(pwd)"
+
+cmake \
+    -DCMAKE_BUILD_TYPE='Coverage' \
+    ../stitcher
+make "-j$(nproc)"
+ctest \
+    "-j$(nproc)" \
+    -E 'test_airmap_stitcher' # TODO: BOSS-812
+
+python3 \
+    -m pip \
+        install \
+           --user \
+        gcovr
+
+mkdir -p "${BUILD_DIR}/coverage"
+python3 \
+    -m gcovr \
+    -r "${BUILD_DIR}/../stitcher" \
+    -j "$(nproc)"\
+    --html --html-details "${BUILD_DIR}/coverage/coverage.html" \
+    -d \
+    "${BUILD_DIR}"
+
+tar -cJf coverage.tar.xz ./coverage
+

--- a/stitcher/CMakeLists.txt
+++ b/stitcher/CMakeLists.txt
@@ -2,6 +2,16 @@ cmake_minimum_required(VERSION 3.6)
 
 project("airmap-panorama-stitcher")
 
+string(COMPARE EQUAL "${CMAKE_BUILD_TYPE}" "Coverage" IS_COVERAGE_BUILD)
+if (IS_COVERAGE_BUILD)
+    message(STATUS "Enabling coverage build")
+    set(CMAKE_BUILD_TYPE 'Debug')
+    #
+    # Assumes GCOV-compatible compiler such as GCC or Clang.
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+endif()
+
 find_package(OpenCV 4.2 REQUIRED)
 
 # Boost is a development dependency and this binary has very


### PR DESCRIPTION
**Pull Request Checklist**
- [:heavy_check_mark:] The PR's heading starts with '[[BOSS-758]](https://airmap.atlassian.net/browse/BOSS-758) ...'
  This will help us track issues, auto-generate release notes and keep the PRs focused.
- [:x:] New unit tests added.
  You would have to gather broad consensus to not comply here. Try not to seek it.
- [:heavy_check_mark:] The PR is well described.
  - `cd scripts && bash ./coverage.bash`

An example coverage report was attached to BOSS-758